### PR TITLE
Remove separate build user and run as root.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,12 @@ MAINTAINER Spencer Rinehart <anubis@overthemonkey.com>
 RUN curl -o /etc/pacman.d/mirrorlist "https://www.archlinux.org/mirrorlist/?country=all&protocol=https&ip_version=6&use_mirror_status=on" && sed -i 's/^#//' /etc/pacman.d/mirrorlist
 
 # Update system and install node.js/npm.
-RUN pacman-key --refresh-keys && pacman --sync --refresh --noconfirm --noprogressbar --quiet && pacman --sync --noconfirm --noprogressbar --quiet archlinux-keyring openssl pacman && pacman-db-upgrade && pacman --sync --sysupgrade --noconfirm --noprogressbar --quiet && pacman --sync --noconfirm --noprogressbar --quiet nodejs npm
+RUN pacman-key --refresh-keys && \
+    pacman --sync --refresh --noconfirm --noprogressbar --quiet && \
+    pacman --sync --noconfirm --noprogressbar --quiet archlinux-keyring openssl pacman && \
+    pacman-db-upgrade && \
+    pacman --sync --sysupgrade --noconfirm --noprogressbar --quiet && \
+    pacman --sync --noconfirm --noprogressbar --quiet nodejs npm
 
 # Create a separate user to run npm as.  Root access shouldn't typically be
 # necessary.  Specify the uid so that it is unique including from the host.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,22 +12,12 @@ RUN pacman-key --refresh-keys && \
     pacman --sync --sysupgrade --noconfirm --noprogressbar --quiet && \
     pacman --sync --noconfirm --noprogressbar --quiet nodejs npm
 
-# Create a separate user to run npm as.  Root access shouldn't typically be
-# necessary.  Specify the uid so that it is unique including from the host.
-RUN useradd --uid 59944 --create-home --comment "Build User" build
-
-RUN mkdir /code && chown build:build /code
+RUN mkdir /code
 WORKDIR /code
 
-USER build
-ENV HOME /home/build
-
-# Set the umask to 002 so that the group has write access inside and outside the
-# container.
-ADD umask.sh $HOME/umask.sh
+ENV HOME /root
 
 # Setup PATH to prioritize local npm bin ahead of system PATH.
 ENV PATH node_modules/.bin:$PATH
 
-ENTRYPOINT ["/home/build/umask.sh"]
 CMD ["npm", "install"]

--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ This is a base image for building [node.js][node.js] [npm][npm] repositories.
 This docker image builds on top of Arch Linux's base/archlinux image for the
 purpose of building projects using npm.  It provides several key features:
 
-* A non-root user (`build`) for executing the image build.  This is important
-  for security purposes and to ensure that the package doesn't require root
-  permissions to be built.
 * Access to the build location will be in the volume located at `/code`.  This
   directory will be the default working directory.
 * The npm bin directory is automatically included in `PATH` using the relative
@@ -34,21 +31,31 @@ docker run -i -t --rm -v /tmp/my-code:/code nubs/npm-build npm update
 ```
 
 ## Permissions
-This image uses a build user to run npm  This means that your file permissions
-must allow this user to write to certain folders like `node_modules`.  The
-easiest way to do this is to create a group and give that group write access to
-the necessary folders.
+This image runs as root (PID 0), but for security purposes it is recommended to
+use Docker's [user namespace functionality][docker-user-namespaces] to map that
+to a non-privileged user on your host system.
+
+If you use volume mounting of your project (e.g., to run `npm install` inside
+the container but want to modify the host `node_modules` directory), then you
+may run into permission issues.
+
+Without Docker's user namespaces, the container will create files/directories
+with root ownership on your host which may cause issues when trying to access
+them as a non-root user.
+
+When using Docker's user namespaces, the container will be running under a
+different user.  You may have to adjust permissions on the directory to allow
+the user to create/modify files.  For example, giving an `/etc/setuid` and
+`/etc/subgid` that contains `dockremap:165536:65536` and a docker daemon
+running using this default mapping: `docker daemon --userns-remap=default`,
+you would need to run the following to give the container access to run `npm
+install` and yourself access to do so on the host:
 
 ```bash
-groupadd --gid 59944 npm-build
+groupadd --gid 165536 subgid-root
 chmod -R g+w node_modules
-chgrp -R npm-build node_modules
-```
-
-You may also want to give your user access to files created by the build user.
-
-```bash
-usermod -a -G 59944 "$(whoami)"
+chgrp -R subgid-root node_modules
+usermod -a -G subgid-root "$(whoami)"
 ```
 
 ### Dockerfile build
@@ -62,11 +69,7 @@ process alone could look like this:
 ```dockerfile
 FROM nubs/npm-build
 
-USER root
-
 RUN pacman --sync --noconfirm --noprogressbar --quiet somepackage
-
-USER build
 ```
 
 You can then build this docker image and run it against your `package.json`
@@ -85,4 +88,5 @@ license text.
 
 [node.js]: http://nodejs.org/
 [npm]: https://www.npmjs.org/
+[docker-use-namespaces]: https://docs.docker.com/engine/reference/commandline/daemon/#daemon-user-namespace-options
 [LICENSE]: https://github.com/nubs/docker-npm-build/blob/master/LICENSE

--- a/umask.sh
+++ b/umask.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-umask 002
-eval "exec ${@}"


### PR DESCRIPTION
Instead of bringing in the difficulty of a build user that needs to be setup on the host, instead user namespaces can be used to provide a similar level of security for the host system.  This should make this image easier to work with, especially for custom additions and running on non-Linux development machines.

Group setup is still necessary for volume mounting permissions to work under many setups, but it's configurable by the user instead of hard-coded by this docker image.

This should also hopefully improve the experience when trying to run this image on an OSX or Windows host, especially using the newly in beta project released by Docker: https://blog.docker.com/2016/03/docker-for-mac-windows-beta/.
